### PR TITLE
Upgrade MiniMessage to latest (v4.10.1)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -187,13 +187,14 @@
         <dependency>
             <groupId>com.velocitypowered</groupId>
             <artifactId>velocity-api</artifactId>
-            <version>3.1.0</version>
+            <version>3.1.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>net.kyori</groupId>
             <artifactId>adventure-text-minimessage</artifactId>
             <version>4.10.1</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.bstats</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -193,7 +193,7 @@
         <dependency>
             <groupId>net.kyori</groupId>
             <artifactId>adventure-text-minimessage</artifactId>
-            <version>4.1.0-SNAPSHOT</version>
+            <version>4.10.1</version>
         </dependency>
         <dependency>
             <groupId>org.bstats</groupId>

--- a/src/main/java/com/oskarsmc/send/command/SendCommand.java
+++ b/src/main/java/com/oskarsmc/send/command/SendCommand.java
@@ -25,7 +25,6 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicInteger;
 

--- a/src/main/java/com/oskarsmc/send/command/SendCommand.java
+++ b/src/main/java/com/oskarsmc/send/command/SendCommand.java
@@ -15,6 +15,7 @@ import com.velocitypowered.api.proxy.Player;
 import com.velocitypowered.api.proxy.ProxyServer;
 import com.velocitypowered.api.proxy.server.RegisteredServer;
 import net.kyori.adventure.text.minimessage.MiniMessage;
+import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 import net.luckperms.api.LuckPerms;
 import net.luckperms.api.LuckPermsProvider;
 import net.luckperms.api.model.group.Group;
@@ -146,9 +147,21 @@ public class SendCommand {
         if (sendable.type() == Sendable.Type.UNKNOWN) {
             context.getSender().sendMessage(plugin.sendSettings.getMessageParsed("send-no-player"));
         } else if (sendable.type() == Sendable.Type.PLAYER) {
-            context.getSender().sendMessage(MiniMessage.get().parse(plugin.sendSettings.getMessageRaw("send-success-singular"), Map.of("player", sendable.players().get(0).getUsername(), "server", ((RegisteredServer) context.get("server")).getServerInfo().getName())));
+            context.getSender().sendMessage(
+                    MiniMessage.miniMessage().deserialize(
+                            plugin.sendSettings.getMessageRaw("send-success-singular"),
+                            Placeholder.parsed("player", sendable.players().get(0).getUsername()),
+                            Placeholder.parsed("server", ((RegisteredServer) context.get("server")).getServerInfo().getName())
+                    )
+            );
         } else if (sendable.type() == Sendable.Type.PLAYERS || sendable.type() == Sendable.Type.SERVER) {
-            context.getSender().sendMessage(MiniMessage.get().parse(plugin.sendSettings.getMessageRaw("send-success-plural"), Map.of("players", "" + sendable.players().size(), "server", ((RegisteredServer) context.get("server")).getServerInfo().getName())));
+            context.getSender().sendMessage(
+                    MiniMessage.miniMessage().deserialize(
+                            plugin.sendSettings.getMessageRaw("send-success-plural"),
+                            Placeholder.parsed("players", String.valueOf(sendable.players().size())),
+                            Placeholder.parsed("server", ((RegisteredServer) context.get("server")).getServerInfo().getName())
+                    )
+            );
         }
     }
 

--- a/src/main/java/com/oskarsmc/send/configuration/SendSettings.java
+++ b/src/main/java/com/oskarsmc/send/configuration/SendSettings.java
@@ -86,7 +86,7 @@ public final class SendSettings {
     }
 
     public Component getMessageParsed(String key) {
-        return MiniMessage.get().parse(this.messages.getString(key));
+        return MiniMessage.miniMessage().deserialize(this.messages.getString(key));
     }
 
     public String getMessageRaw(String key) {


### PR DESCRIPTION
This PR updates the dependency to its latest available version and makes the appropriate modifications to the code. Notably, the MiniMessage#parse() method has been completely removed from the library, and now MiniMessage#deserialize() must be used. The trickiest part was figuring out the API changes, since they appear to be fairly undocumented.

Tested on latest Velocity build (`3.1.2-SNAPSHOT-121`).